### PR TITLE
Fix installation of ffi due to nan change

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "~1.0.1",
     "ref": "https://github.com/icenium/ref/tarball/master",
     "ref-struct": "https://github.com/telerik/ref-struct/tarball/master",
-    "nan": "*",
+    "nan": "1",
     "prebuilt": "https://github.com/tailsu/node-prebuilt/tarball/master"
   },
   "devDependencies": {


### PR DESCRIPTION
NaN has breaking change and ffi is unable to use the latest versions. Only versions 1.x are working ( https://github.com/node-ffi/node-ffi/commit/e761dd15b9bc680285db4c62df2aed0f316280a1 )